### PR TITLE
Fix dependency check

### DIFF
--- a/plugin/my_awesome_plugin.lua
+++ b/plugin/my_awesome_plugin.lua
@@ -1,13 +1,13 @@
-if not vim.fn.has("nvim-0.7.0") then
+if vim.fn.has("nvim-0.7.0") == 0 then
   vim.api.nvim_err_writeln("my_awesome_plugin requires at least nvim-0.7.0.1")
   return
 end
 
 -- make sure this file is loaded only once
-if vim.g.loaded_my_awesome_plugin then
+if vim.g.loaded_my_awesome_plugin == 1 then
   return
 end
-vim.g.loaded_my_awesome_plugin = true
+vim.g.loaded_my_awesome_plugin = 1
 
 -- create any global command that does not depend on user setup
 -- usually it is better to define most commands/mappings in the setup function
@@ -18,3 +18,4 @@ vim.api.nvim_create_user_command(
   "MyPluginGenericGreet",
   my_awesome_plugin.generic_greet,
   {})
+


### PR DESCRIPTION
As `vim.fn.has("…")` returns a number value. Checking for a boolean has no effect.

Test:
`if vim.fn.has("nvim-0.9.0") then print("prints but it shouldn't") end`
prints

`if vim.fn.has("nvim-0.9.0") == 1 then print("prints but it shouldn't") end`
won't print

Second thing is that the usuall way `loaded_…` vars are organized, is also in 0 / 1 number values. So I think we should give in on this one, too.

<sub>Even though I would prefer that the common way of handling both of those, would be a boolean. But that's something beyond a single mans power.</sub>