### PR TITLE
Add rename command to makefile for renaming the plugin name across the project.

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -23,4 +23,29 @@ watch:
 	@find spec/ ../lua/ -name '*.lua' \
 	  | entr make test SPEC=$(SPEC)
 
+rename:
+	@if [ "$(words $(MAKECMDGOALS))" -ne 3 ]; then \
+		echo "Error: Incorrect number of arguments. Usage: make rename current_plugin_name new_plugin_name"; \
+		exit 1; \
+	fi;
+	$(eval CURRENT_NAME=$(word 2,$(MAKECMDGOALS)))
+	$(eval NEW_NAME=$(word 3,$(MAKECMDGOALS)))
+	@echo "Renaming all references from '$(CURRENT_NAME)' to $(NEW_NAME)"
+	# Set LC_ALL to C for compatibility
+	LC_ALL=C; \
+	# Rename in file contents, excluding the Makefile itself
+	for file in $$(find ../ -type f ! -path '../.git/*' ! -path './Makefile' -exec grep -Il '$(CURRENT_NAME)' {} \;); do \
+		sed -i "" "s/$(CURRENT_NAME)/$(NEW_NAME)/g" "$$file"; \
+	done
+	# Rename files, excluding the Makefile
+	for file in $$(find ../ -type f -name '*$(CURRENT_NAME)*' ! -path '../.git/*' ! -path './Makefile'); do \
+		mv "$$file" "$$(echo $$file | sed 's/$(CURRENT_NAME)/$(NEW_NAME)/')"; \
+	done
+	# Rename directories, excluding .git and the Makefile's directory
+	for dir in $$(find ../ -type d -name '*$(CURRENT_NAME)*' ! -path '../.git/*' ! -path './'); do \
+		mv "$$dir" "$$(echo $$dir | sed 's/$(CURRENT_NAME)/$(NEW_NAME)/')"; \
+	done
+	%:
+	@:
+
 all: prepare test


### PR DESCRIPTION
This command will rename filenames, file contents, and directory names so that renaming ALL plugin references is not such a hassle.

### Usage
```bash
make rename current_plugin_name new_plugin_name
```

I noticed the doc/plugin-name.txt has a different format so that one needs manual renaming.